### PR TITLE
Release @metamask/spdx-compare v2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ```javascript
 var assert = require('assert')
-var compare = require('spdx-compare')
+var compare = require('@metamask/spdx-compare')
 
 assert(compare.gt('GPL-3.0', 'GPL-2.0'))
 assert(compare.gt('GPL-3.0-only', 'GPL-2.0-only'))

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "spdx-compare",
+  "name": "@metamask/spdx-compare",
   "description": "compare SPDX license expressions",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "author": "Kyle E. Mitchell <kyle@kemitchell.com> (https://kemitchell.com)",
   "dependencies": {
     "spdx-expression-parse": "^3.0.0",
@@ -21,8 +21,11 @@
     "standards"
   ],
   "license": "MIT",
-  "repository": "kemitchell/spdx-compare.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/MetaMask/spdx-compare.js"
+  },
   "scripts": {
-    "test": "defence -i javascript README.md | sed 's!spdx-compare!./!' | node"
+    "test": "defence -i javascript README.md | sed 's!@metamask/spdx-compare!./!' | node"
   }
 }


### PR DESCRIPTION
This is the first release as `@metamask/spdx-compare`.

Changes since fork from upstream `spdx-compare@1.0.0`:

- Remove dependency `array-find-index` (#2) 
- docs: fix usage example for Node.js >= v10 (#1)
